### PR TITLE
Fixed Error When Using -Wait with Enable-ADRole

### DIFF
--- a/Source/Public/Wait-ADRole.ps1
+++ b/Source/Public/Wait-ADRole.ps1
@@ -139,7 +139,7 @@ function Wait-ADRole {
         }
 
         if ($PassThru) {
-            Get-JAzADRole -Activated
+            Get-ADRole -Activated
             | Where-Object { $_.roleAssignmentScheduleId -in $RoleRequests.TargetScheduleId }
         }
     }


### PR DESCRIPTION
When using the `-Wait` parameter with `Enable-ADRole`, you get an error. This error does not occur when piping `Enable-ADRole` to `Wait-ADRole`.

```PowerShell
PS > Enable-ADRole 'Global Reader (LJnv8vs6uUa3z6Em7nTEUZY-Uygeo0pJj_wBT3Lkhj8-1-e)' -Justification 'foo' -Wait
Get-JAzADRole: C:\Program Files\PowerShell\Modules\jaz.pim\0.0.8\Public\Wait-ADRole.ps1:142
Line |
 142 |              Get-JAzADRole -Activated
     |              ~~~~~~~~~~~~~
     | The term 'Get-JAzADRole' is not recognized as a name of a cmdlet, function, script file, or executable
     | program. Check the spelling of the name, or if a path was included, verify that the path is correct
     | and try again.
```

This PR fixes that error by replacing `Get-JAzADRole` with `Get-ADRole` within the `Wait-ADRole` function.